### PR TITLE
feat: simplify recur N omp

### DIFF
--- a/philtorch/csrc/host_recur2.cpp
+++ b/philtorch/csrc/host_recur2.cpp
@@ -57,8 +57,8 @@ void host_batch_mat_recur_second_order(const scalar_t *A, const scalar_t *x,
         }
     });
 
-    std::inclusive_scan(buffer.begin(), buffer.end(),
-                        buffer.begin(), recur2_binary_op<scalar_t>);
+    std::inclusive_scan(buffer.begin(), buffer.end(), buffer.begin(),
+                        recur2_binary_op<scalar_t>);
 
     at::parallel_for(0, n_steps, 1, [&](int64_t start, int64_t end) {
         for (auto i = start; i < end; i++) {
@@ -91,8 +91,8 @@ void host_share_mat_recur_second_order(const scalar_t *A, const scalar_t *x,
         }
     });
 
-    std::inclusive_scan(buffer.begin(), buffer.end(),
-                        buffer.begin(), recur2_binary_op<scalar_t>);
+    std::inclusive_scan(buffer.begin(), buffer.end(), buffer.begin(),
+                        recur2_binary_op<scalar_t>);
 
     at::parallel_for(0, total_steps, 1, [&](int64_t start, int64_t end) {
         for (auto i = start; i < end; i++) {
@@ -150,9 +150,4 @@ at::Tensor mat_recur_second_order_cpu_impl(const at::Tensor &A,
 TORCH_LIBRARY(philtorch, m) {
     m.def("philtorch::recur2(Tensor A, Tensor zi, Tensor x) -> Tensor");
     m.def("philtorch::recurN(Tensor A, Tensor zi, Tensor x) -> Tensor");
-    m.def("philtorch::recurN_OMP(Tensor A, Tensor zi, Tensor x) -> Tensor");
-}
-
-TORCH_LIBRARY_IMPL(philtorch, CPU, m) {
-    m.impl("recur2", &mat_recur_second_order_cpu_impl);
 }

--- a/philtorch/csrc/host_recurN.cpp
+++ b/philtorch/csrc/host_recurN.cpp
@@ -196,7 +196,6 @@ at::Tensor mat_recur_N_order_cpu_impl(const at::Tensor &A, const at::Tensor &zi,
             x.scalar_type(), "host_batch_mat_recur_N_order", [&] {
                 host_batch_mat_recur_N_order<scalar_t>(
                     Ax.const_data_ptr<scalar_t>(),
-                    // x_contiguous.const_data_ptr<scalar_t>(),
                     out.mutable_data_ptr<scalar_t>(), n_steps * n_batches,
                     order);
             });
@@ -259,4 +258,5 @@ at::Tensor mat_recur_N_order_cpu_omp_impl(const at::Tensor &A,
 
 TORCH_LIBRARY_IMPL(philtorch, CPU, m) {
     m.impl("recurN", &mat_recur_N_order_cpu_omp_impl);
+    m.impl("recur2", &mat_recur_N_order_cpu_omp_impl);
 }


### PR DESCRIPTION
## Changes

- Pre-copy initials and input to the output tensor.
- Implement OMP kernel when `A` is shared across batches.
- Remove `recurN_OMP` declaration.
- Replace `recur2` implementation with `recurN` runner since it's faster.

@josephDSPLab, since we have removed the parallel execution policy variable in #1, `std::inclusive_scan` has no advantage anymore. I still keep the functions just in case we find a way to leverage them again.

## TODO

- Parallelise the inner for-loops for matrix multiplication.