### PR TITLE
Add MPS scalar LTI recurrence

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,57 @@
+# Copilot instructions for `philtorch`
+
+## Build, test, and lint commands
+
+Use pixi as the source of truth for environment/setup in this repository.
+
+```bash
+# install/build project from pixi.toml instructions
+pixi install philtorch
+```
+
+```bash
+# run full tests (pytest options are configured in pyproject.toml)
+pixi run pytest
+
+# run a single test file
+pixi run pytest tests/test_lti_lfilter.py
+
+# run a single test function
+pixi run pytest tests/test_lti_lfilter.py::test_time_invariant_filter
+```
+
+```bash
+# lint command used by CI
+pixi run python -m pip install flake8
+pixi run flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+pixi run flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+```
+
+## High-level architecture
+
+`philtorch` provides differentiable digital filtering APIs in PyTorch, with backend dispatch to compiled kernels when available.
+
+1. `philtorch/lti/*` implements **time-invariant** filters and recurrences.
+2. `philtorch/lpv/*` implements **time-varying (parameter-varying)** filters and recurrences.
+3. `philtorch/lti/ssm.py` and `philtorch/lpv/ssm.py` are the core state-space engines; they route execution between compiled ops (`torch.ops.philtorch.*`), optional Helion/PararNN paths, and pure PyTorch fallbacks.
+4. `philtorch/__init__.py` loads/registers extension ops and fake/autograd registrations. `setup.py` builds native sources from `philtorch/csrc/*.cpp` and `*.cu`.
+
+Typical flow: API-level `lfilter`/`state_space` normalization -> backend/form selection -> recurrence execution backend.
+
+## Key conventions in this codebase
+
+- **Filter coefficient convention**: denominator `a` excludes `a0`; SciPy-equivalent calls prepend `1.0` in tests (`[1.0] + a.tolist()`).
+- **Shape contracts are strict**: LTI functions accept static coefficients (`(N,)`, `(B,N)` style), while LPV functions encode time-varying coefficients (`(B,T,M)` style).
+- **Filter forms are explicit API choices**: use only `df2`, `tdf2`, `df1`, `tdf1`; behavior and state handling depend on form.
+- **Backend choice is explicit and meaningful**:
+  - LTI `lfilter`: `backend="ssm"` or `backend="diag_ssm"`.
+  - LPV `lfilter`: `backend="ssm"` or `backend="torchlpc"`.
+- **`unroll_factor` affects backend path**: in state-space code, values greater than 1 force pure PyTorch unrolled recursion instead of extension-backed recursion.
+- **Extension loading is optional**: code must keep fallback behavior working when compiled extensions are unavailable.
+
+<!-- mermaid-ai-skills:start -->
+## Mermaid Diagrams
+
+When the user asks to create, edit, or visualize a diagram, follow the
+instructions in `.github/instructions/mermaid.instructions.md`.
+<!-- mermaid-ai-skills:end -->

--- a/.github/instructions/mermaid.instructions.md
+++ b/.github/instructions/mermaid.instructions.md
@@ -1,0 +1,85 @@
+---
+applyTo: "**"
+---
+# Mermaid AI Skills
+
+When the user asks to create, edit, or visualize any diagram, use the Mermaid
+VS Code extension tools and commands described below.
+
+## Workflow
+
+1. Determine the diagram type and generate Mermaid syntax.
+2. Write the diagram to a `.mmd` file in the project.
+3. Validate syntax: correct first-line keyword, arrow types, balanced brackets.
+4. Preview via the Mermaid extension — open the `.mmd` file (auto-preview) or run
+   **MermaidChart: Preview Diagram** (`mermaidChart.preview`).
+
+## LM Tools — call these for every diagram interaction
+
+- `mermaid-diagram-validator` — validate Mermaid syntax before presenting any diagram
+- `mermaid-diagram-preview` — render a live preview inside VS Code after generating
+- `get-syntax-docs-mermaid` — fetch correct syntax docs for any diagram type
+
+## VS Code Commands
+
+Invoke via Command Palette or the VS Code command API (GitHub Copilot in VS Code only).
+Do not invent command IDs. Prefer writing/editing `.mmd` files when a command is not needed.
+
+### Diagram editing & preview
+- **Preview** (`mermaidChart.preview`) — preview the active Mermaid editor (`.mmd` / `.mermaid` must be open).
+- **Create Diagram** (`mermaidChart.createMermaidFile`) — creates a demo flowchart and opens preview side by side.
+- **Repair Diagram** (`mermaidChart.repairDiagram`) — Mermaid AI repair for the active diagram; uses Mermaid AI credits — tell the user before running.
+- **Improve Diagram** (`mermaidChart.improveDiagram`) — uses Copilot / LM API; suggests layout + styling variants for the active diagram.
+
+### Generate diagrams (GitHub Copilot required)
+- **Generate Diagram from Code** (`mermaidChart.generateDiagramFromCode`)
+- **Generate Cloud Diagram** (`mermaidChart.generateCloudDiagram`)
+- **Generate ER Diagram** (`mermaidChart.generateERDiagram`)
+- **Generate Docker Diagram** (`mermaidChart.generateDockerDiagram`)
+- **Open AI Chat** (`mermaidChart.openCopilotChat`)
+
+### Mermaid Chart cloud
+- **Login** (`mermaidChart.login`) / **Logout** (`mermaidChart.logout`)
+- **Connect Diagram** (`mermaidChart.connectDiagramToMermaidChart`) — link a local diagram to Mermaid Chart.
+- **Sync Diagram** (`mermaidChart.syncDiagramWithMermaid`) — only for diagrams already connected (frontmatter has `id:`). Example:
+  ```yaml
+  ---
+  id: cbd9e9ba-a2cb-47c5-a98e-8c28a753428d
+  ---
+  ```
+
+### Review Mermaid Sync
+For diagrams updated by the Mermaid Chart GitHub Sync app (or pre-commit regenerate):
+- **Review Mermaid Sync** (`mermaidChart.reviewAppCommits`) — start / open the review flow.
+- **Regenerate with Mermaid AI** (`mermaidChart.regenerateDiagramWithMermaidAI`) — regenerate from source references.
+Do not manually rewrite diagrams managed by this workflow. Accept/reject/diff UI actions stay in the extension UI.
+
+### Install / update this pack
+- **MermaidChart: Install AI Skills…** (`mermaidChart.installAiSkills`)
+
+## @mermaid-chart slash commands
+
+| Command | Purpose |
+|---|---|
+| `/generate_diagram_from_code` | General diagram from any source file |
+| `/generate_execution_sequence` | Sequence diagram from code flow |
+| `/generate_er_diagram` | ER diagram from schema / models |
+| `/generate_cloud_architecture_diagram` | Cloud / CI-CD architecture |
+| `/generate_docker_diagram` | Architecture from Dockerfiles |
+| `/generate_c4_topdown_architecture` | C4 top-down architecture |
+| `/analyze_code_ownership` | Code ownership diagram |
+| `/generate_dependency_diagram` | Dependency / security visualisation |
+
+## Rules
+
+1. Always call `mermaid-diagram-validator` before showing any diagram.
+2. Always call `mermaid-diagram-preview` after generating a diagram.
+3. Use `get-syntax-docs-mermaid` before generating an unfamiliar diagram type.
+4. Prefer `@mermaid-chart` slash commands for complex generation.
+5. Write diagrams to `.mmd` files; never return unvalidated Mermaid syntax.
+6. Warn the user before Repair (Mermaid AI credits).
+7. Cooperate with the Sync workflow — do not manually regenerate managed diagrams.
+
+## Docs
+
+More commands and features: https://marketplace.visualstudio.com/items?itemName=MermaidChart.vscode-mermaid-chart

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -66,15 +66,9 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install libomp and llvm
+      - name: Install native build dependencies
         run: |
           brew install llvm libomp
-      - name: Configure compiler for OpenMP
-        run: |
-          LLVM_PREFIX=$(brew --prefix llvm)
-          LIBOMP_PREFIX=$(brew --prefix libomp)
-          echo "CXX=$LLVM_PREFIX/bin/clang++" >> $GITHUB_ENV
-          echo "CPPFLAGS=-I$LIBOMP_PREFIX/include" >> $GITHUB_ENV
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -69,6 +69,13 @@ jobs:
       - name: Install native build dependencies
         run: |
           brew install llvm libomp
+      - name: Configure native build environment
+        run: |
+          LLVM_PREFIX="$(brew --prefix llvm)"
+          LIBOMP_PREFIX="$(brew --prefix libomp)"
+          echo "CXX=$LLVM_PREFIX/bin/clang++" >> "$GITHUB_ENV"
+          echo "CPPFLAGS=-I$LIBOMP_PREFIX/include" >> "$GITHUB_ENV"
+          echo "LDFLAGS=-L$LIBOMP_PREFIX/lib -Wl,-rpath,$LIBOMP_PREFIX/lib" >> "$GITHUB_ENV"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -75,7 +75,6 @@ jobs:
           LIBOMP_PREFIX="$(brew --prefix libomp)"
           echo "CXX=$LLVM_PREFIX/bin/clang++" >> "$GITHUB_ENV"
           echo "CPPFLAGS=-I$LIBOMP_PREFIX/include" >> "$GITHUB_ENV"
-          echo "LDFLAGS=-L$LIBOMP_PREFIX/lib -Wl,-rpath,$LIBOMP_PREFIX/lib" >> "$GITHUB_ENV"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -83,6 +82,8 @@ jobs:
       - name: Install torch and build
         run: |
           pip install torch
+          TORCH_LIB="$(python -c 'from pathlib import Path; import torch; print(Path(torch.__file__).parent / "lib")')"
+          export LDFLAGS="-L$TORCH_LIB -Wl,-rpath,$TORCH_LIB"
           pip install -e .[dev] --no-build-isolation
       - name: Verify extension op dispatch on macOS
         run: |

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 recursive-include philtorch *.txt
 recursive-include philtorch *.cuh
 recursive-include philtorch *.cu
+recursive-include philtorch *.mm
 exclude tests/*

--- a/benchmarks/benchmark_mps_lti_recur.py
+++ b/benchmarks/benchmark_mps_lti_recur.py
@@ -1,0 +1,143 @@
+import gc
+import platform
+import threading
+import time
+
+import torch
+import torch.utils.benchmark as benchmark
+
+import philtorch  # noqa: F401 - loads the native operator registrations
+
+CASES = (
+    (1, 4_096, False),
+    (1, 262_144, False),
+    (16, 4_096, True),
+    (64, 65_536, True),
+    (256, 4_096, True),
+)
+NUM_THREADS = torch.get_num_threads()
+
+
+def synchronized_mps_timer():
+    torch.mps.synchronize()
+    return time.perf_counter()
+
+
+def measure_runtime(function, timer=time.perf_counter):
+    measurement = benchmark.Timer(
+        stmt="function()",
+        globals={"function": function},
+        timer=timer,
+        num_threads=NUM_THREADS,
+    ).blocked_autorange(min_run_time=0.5)
+    return measurement.median * 1_000, measurement.iqr * 1_000
+
+
+def profile_cpu_peak(function):
+    with torch.profiler.profile(
+        activities=[torch.profiler.ProfilerActivity.CPU],
+        profile_memory=True,
+        record_shapes=True,
+        acc_events=True,
+    ) as profiler:
+        result = function()
+
+    memory_changes = []
+    for event in profiler.events():
+        memory_change = event.self_cpu_memory_usage
+        if memory_change:
+            timestamp = (
+                event.time_range.start if memory_change > 0 else event.time_range.end
+            )
+            memory_changes.append((timestamp, memory_change))
+
+    current = 0
+    peak = 0
+    for _, memory_change in sorted(memory_changes, key=lambda change: change[0]):
+        current += memory_change
+        peak = max(peak, current)
+
+    del result
+    return peak
+
+
+def profile_mps_peak(function, repeats=20):
+    torch.mps.synchronize()
+    gc.collect()
+    torch.mps.empty_cache()
+    baseline = torch.mps.current_allocated_memory()
+    peak = [baseline]
+    ready = threading.Event()
+    stop = threading.Event()
+
+    def sample_allocator():
+        ready.set()
+        while not stop.is_set():
+            peak[0] = max(peak[0], torch.mps.current_allocated_memory())
+
+    sampler = threading.Thread(target=sample_allocator, daemon=True)
+    sampler.start()
+    ready.wait()
+    try:
+        with torch.profiler.profile(
+            activities=[torch.profiler.ProfilerActivity.CPU], acc_events=True
+        ):
+            with torch.profiler.record_function("mps_lti_recur_memory"):
+                for _ in range(repeats):
+                    result = function()
+                    torch.mps.synchronize()
+                    del result
+    finally:
+        stop.set()
+        sampler.join()
+
+    return peak[0] - baseline
+
+
+def main():
+    if not torch.backends.mps.is_available():
+        raise RuntimeError("MPS is not available")
+
+    print(f"Platform: {platform.platform()}")
+    print(f"PyTorch: {torch.__version__}")
+    print(f"CPU threads: {NUM_THREADS}")
+    print()
+    print(
+        "| B | T | Coefficients | CPU median ms (IQR) | "
+        "MPS median ms (IQR) | Speedup | CPU peak MiB | "
+        "MPS peak MiB | Memory ratio |"
+    )
+    print("| ---: | ---: | :--- | ---: | ---: | ---: | ---: | ---: | ---: |")
+
+    torch.manual_seed(5)
+    for batch, steps, batched_decay in CASES:
+        coefficient_count = batch if batched_decay else 1
+        a_cpu = (torch.rand(coefficient_count) - 0.5) * 0.9
+        zi_cpu = torch.randn(batch)
+        x_cpu = torch.randn(batch, steps)
+        mps_inputs = tuple(value.to("mps") for value in (a_cpu, zi_cpu, x_cpu))
+
+        cpu_function = lambda: torch.ops.philtorch.lti_recur(a_cpu, zi_cpu, x_cpu)
+        mps_function = lambda: torch.ops.philtorch.lti_recur(*mps_inputs)
+
+        expected = cpu_function()
+        actual = mps_function().cpu()
+        torch.testing.assert_close(actual, expected, rtol=1e-5, atol=1e-6)
+        del actual, expected
+
+        cpu_ms, cpu_iqr_ms = measure_runtime(cpu_function)
+        mps_ms, mps_iqr_ms = measure_runtime(mps_function, timer=synchronized_mps_timer)
+        cpu_mib = profile_cpu_peak(cpu_function) / 2**20
+        mps_mib = profile_mps_peak(mps_function) / 2**20
+        coefficients = "batched" if batched_decay else "shared"
+        print(
+            f"| {batch} | {steps} | {coefficients} | "
+            f"{cpu_ms:.4f} ({cpu_iqr_ms:.4f}) | "
+            f"{mps_ms:.4f} ({mps_iqr_ms:.4f}) | "
+            f"{cpu_ms / mps_ms:.2f}x | {cpu_mib:.3f} | {mps_mib:.3f} | "
+            f"{cpu_mib / mps_mib:.2f}x |"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/philtorch/__init__.py
+++ b/philtorch/__init__.py
@@ -233,6 +233,8 @@ if EXTENSION_LOADED:
     @torch.library.register_fake("philtorch::lti_recur")
     def _(A, zi, x):
         torch._check(A.ndim <= 1, "A must be 1D or scalar.")
+        torch._check(zi.ndim == 1, "zi must be 1D.")
+        torch._check(x.ndim == 2, "x must be 2D.")
         torch._check(
             zi.shape[0] == x.shape[0], "x and zi must have the same batch size."
         )

--- a/philtorch/__init__.py
+++ b/philtorch/__init__.py
@@ -235,6 +235,7 @@ if EXTENSION_LOADED:
         torch._check(A.ndim <= 1, "A must be 1D or scalar.")
         torch._check(zi.ndim == 1, "zi must be 1D.")
         torch._check(x.ndim == 2, "x must be 2D.")
+        torch._check(x.shape[1] > 0, lambda: "x must contain at least one time step.")
         torch._check(
             zi.shape[0] == x.shape[0], "x and zi must have the same batch size."
         )

--- a/philtorch/csrc/README.md
+++ b/philtorch/csrc/README.md
@@ -231,7 +231,8 @@ The MPS implementations currently require:
 - two-dimensional `x` with shape `(B, T)`; and
 - indexing products that fit in `uint32_t`.
 
-An empty batch or zero-length sequence returns `empty_like(x)` without a Metal dispatch.
+A zero-length sequence is rejected because the custom autograd formula requires a final output state.
+An empty batch with `T > 0` returns `empty_like(x)` without a Metal dispatch.
 Shared and per-batch `a` values use one kernel and a `batched_decay` flag.
 Parallel reassociation can change floating-point rounding relative to a strict serial loop, so tests use explicit `float32` tolerances.
 
@@ -261,7 +262,13 @@ Memory figures exclude inputs and allocator cache but include output and native 
 ## Build and verification
 
 On macOS, `setup.py` adds every `.mm` source to the C++ extension and links the Foundation and Metal frameworks.
-The pixi environment selects Homebrew LLVM and the Homebrew OpenMP headers needed by the other native sources.
+It locates Homebrew LLVM and libomp with `brew --prefix`, selects Homebrew Clang unless `CXX` is already set, and configures the OpenMP include and library paths.
+
+Install the required system packages before creating or rebuilding the environment:
+
+```bash
+brew install llvm libomp
+```
 
 Rebuild the editable extension after changing Objective-C++ or Metal source:
 
@@ -275,7 +282,7 @@ Run focused native recurrence tests with:
 pixi run pytest tests/test_recur_ext.py -q
 ```
 
-The MPS tests cover scalar, shared, and per-batch multipliers, empty sequences, lengths around the 512-element tile boundary, CPU/MPS device dispatch, and gradients against CPU.
+The MPS tests cover scalar, shared, and per-batch multipliers, zero-length rejection, lengths around the 512-element tile boundary, CPU/MPS device dispatch, and gradients against CPU.
 The long replay test uses `T = 512 * 512 + 1`, forcing stage 2 to carry a prefix across more than one 512-total chunk.
 
 ## Invariants to preserve

--- a/philtorch/csrc/README.md
+++ b/philtorch/csrc/README.md
@@ -262,7 +262,8 @@ Memory figures exclude inputs and allocator cache but include output and native 
 ## Build and verification
 
 On macOS, `setup.py` adds every `.mm` source to the C++ extension and links the Foundation and Metal frameworks.
-It locates Homebrew LLVM and libomp with `brew --prefix`, selects Homebrew Clang unless `CXX` is already set, and configures the OpenMP include and library paths.
+It locates Homebrew LLVM and libomp with `brew --prefix`, selects Homebrew Clang unless `CXX` is already set, and uses the Homebrew OpenMP headers.
+The extension links `@rpath/libomp.dylib` through PyTorch's library directory so PyTorch and extension modules share one OpenMP runtime.
 
 Install the required system packages before creating or rebuilding the environment:
 

--- a/philtorch/csrc/README.md
+++ b/philtorch/csrc/README.md
@@ -1,0 +1,291 @@
+# Metal scalar recurrence implementation
+
+This directory contains philtorch's native CPU, CUDA, and Metal sources.
+The Metal implementation of the scalar linear time-invariant recurrence lives in [`lti_recur_mps_replay.mm`](lti_recur_mps_replay.mm).
+It implements
+
+```text
+h[b, t] = a[b or 0] * (t == 0 ? zi[b] : h[b, t - 1]) + x[b, t]
+```
+
+as an associative affine scan.
+MPS dispatch uses one three-stage hierarchical SIMD implementation that replays each tile after scanning compact tile totals.
+
+## Source map
+
+| File | Role |
+| --- | --- |
+| [`host_recur2.cpp`](host_recur2.cpp) | Defines the `philtorch::lti_recur` dispatcher schema. |
+| [`lti_recur_mps_replay.mm`](lti_recur_mps_replay.mm) | Objective-C++ host code and the embedded Metal Shading Language source. |
+| [`../__init__.py`](../__init__.py) | Registers fake implementations and autograd for `philtorch::lti_recur`. |
+| [`../../tests/test_recur_ext.py`](../../tests/test_recur_ext.py) | Checks CPU/MPS parity, boundary lengths, long scans, and gradients. |
+| [`../../benchmarks/benchmark_mps_lti_recur.py`](../../benchmarks/benchmark_mps_lti_recur.py) | Reproduces CPU/MPS runtime and working-memory results. |
+
+## Turning a recurrence into a scan
+
+An `AffinePair { multiplier, value }` represents the function
+
+```text
+f(h) = multiplier * h + value.
+```
+
+The Metal helper composes two adjacent functions in sequence:
+
+```text
+compose_affine(left, right)
+    = (left.multiplier * right.multiplier,
+       left.value * right.multiplier + right.value)
+    = right(left(h)).
+```
+
+Function composition is associative, so these pairs can be evaluated with a parallel prefix scan.
+Composition is not commutative; changing the operand order changes the recurrence.
+
+For each batch, the code scans `T + 1` pairs:
+
+```text
+p[0]     = (0, zi[b])
+p[t + 1] = (a[b or 0], x[b, t])
+identity = (1, 0)
+```
+
+The first pair is a reset function.
+Its zero multiplier makes the scan independent of any state before `zi`.
+Consequently, the value in the inclusive prefix at scan index `t + 1` is exactly `h[b, t]`.
+Out-of-range lanes use the identity pair, which makes partial tiles safe without a separate padding pass.
+
+## Default execution path
+
+```mermaid
+flowchart TB
+    opcall["torch.ops.philtorch.lti_recur(a, zi, x)<br/>MPS dispatcher"]
+      host["lti_recur_mps_impl<br/>validate, make inputs contiguous, allocate scratch"]
+
+    subgraph command["One PyTorch MPS command buffer"]
+        direction TB
+
+         subgraph stage1["1. replay_reduce_tiles"]
+            direction LR
+            grid1["Grid: n_tiles x B<br/>256 threads per group"]
+            load["Each thread loads<br/>2 affine pairs"]
+            simd["8 SIMD32 scans<br/>shuffle offsets 1, 2, 4, 8, 16"]
+            groups["SIMD group 0 reduces<br/>the 8 group totals"]
+            totals["block_totals<br/>B x n_tiles pairs"]
+            grid1 --> load --> simd --> groups --> totals
+        end
+
+      subgraph stage2["2. replay_scan_block_totals"]
+            direction LR
+            grid2["Grid: B<br/>one 256-thread group per batch"]
+            chunks["Scan 512 tile totals per chunk<br/>carry prefix between chunks"]
+            prefixes["block_prefixes<br/>B x n_tiles exclusive pairs"]
+            grid2 --> chunks --> prefixes
+        end
+
+         subgraph stage3["3. replay_scan_tiles"]
+            direction LR
+            grid3["Grid: n_tiles x B<br/>256 threads per group"]
+            reload["Reload 2 input pairs<br/>per thread"]
+            simd2["Repeat the tile-local<br/>SIMD inclusive scan"]
+            combine["Apply one exclusive<br/>prefix per tile"]
+            output["output<br/>B x T float32"]
+            grid3 --> reload --> simd2 --> combine --> output
+        end
+
+        totals --> grid2
+        prefixes --> combine
+    end
+
+    opcall --> host --> grid1
+    output --> result["h[t] = a * h[t - 1] + x[t]"]
+```
+
+Let
+
+```text
+n_steps = T + 1
+n_tiles = ceil(n_steps / 512)
+```
+
+All three kernels are encoded in order into the current PyTorch MPS command buffer.
+That ordering provides the dependencies between stages without a CPU round trip.
+
+### Stage 1: reduce tiles in parallel
+
+`replay_reduce_tiles` launches a two-dimensional grid with one threadgroup for every `(tile, batch)` pair.
+A tile contains 512 affine pairs and a threadgroup contains 256 threads, so thread `lid` owns adjacent elements `2 * lid` and `2 * lid + 1`.
+
+The threadgroup is eight 32-lane SIMD groups:
+
+1. Each thread composes its two elements into one `thread_total`.
+2. `simd_inclusive_affine` scans those totals with `simd_shuffle_up` at offsets 1, 2, 4, 8, and 16.
+3. Lane 31 writes each SIMD group's total to eight entries of threadgroup memory.
+4. SIMD group 0 scans those eight totals, and lane 7 writes the complete tile total to `block_totals`.
+
+This reduction does not write per-element scan results.
+Partial final tiles naturally produce the correct total because missing elements were loaded as identities.
+
+### Stage 2: scan tile totals
+
+`replay_scan_block_totals` launches one 256-thread threadgroup per batch.
+It uses the same two-elements-per-thread SIMD hierarchy to compute the exclusive prefix for each tile.
+
+One threadgroup scans up to 512 tile totals at a time.
+If a sequence has more than 512 tiles, the kernel loops over compact 512-total chunks and carries the last inclusive result into the next chunk.
+This keeps the number of Metal dispatches fixed while supporting sequences longer than `512 * 512` scan elements.
+The result is stored in `block_prefixes`; the first tile receives the identity prefix.
+
+### Stage 3: replay tiles and apply prefixes
+
+`replay_scan_tiles` launches the same `(n_tiles, B)` grid as stage 1 and reloads the input pairs.
+It repeats the SIMD hierarchy, this time reconstructing both tile-local inclusive results owned by each thread.
+Thread zero loads the tile's exclusive prefix into threadgroup memory once, and every valid scan index evaluates
+
+```text
+global_pair = compose_affine(block_prefixes[b, tile],
+                             tile_local_inclusive[b, t + 1])
+output[b, t] = global_pair.value
+```
+
+The synthetic initial-state pair at scan index zero is not written to the output.
+Replaying the scan adds SIMD arithmetic, but it rereads one 4-byte input instead of writing and rereading an 8-byte `AffinePair`.
+This removes the dominant per-element scratch traffic.
+
+## Buffers and launch geometry
+
+An `AffinePair` is two `float` values, or 8 bytes.
+
+| Buffer | Shape | Purpose |
+| --- | --- | --- |
+| `a_contiguous` | `(1,)` or `(B,)` | Shared or per-batch recurrence multiplier. |
+| `zi_contiguous` | `(B,)` | Initial state. |
+| `x_contiguous` | `(B, T)` | Input sequence. |
+| `block_totals` | `(B, n_tiles, 2)` | One affine total per tile. |
+| `block_prefixes` | `(B, n_tiles, 2)` | Exclusive affine prefix before each tile. |
+| `output` | `(B, T)` | Recurrence result. |
+
+Excluding inputs and output, scratch storage is
+
+```text
+16 * B * n_tiles bytes.
+```
+
+Ignoring compact tile metadata, dominant traffic is about 12 bytes per element: read `x` in stages 1 and 3, then write `output`.
+
+The fixed geometry is:
+
+| Property | Value |
+| --- | --- |
+| Tile size | 512 affine pairs |
+| Threads per tile | 256 |
+| Elements per thread | 2 |
+| SIMD width | 32 lanes |
+| SIMD groups per tile | 8 |
+| Metal dispatches | 3 |
+
+The host checks `threadExecutionWidth == 32` and support for at least 256 threads per threadgroup before dispatching.
+The tile, threadgroup, and SIMD constants are coupled; changing one requires updating both Metal kernels and the Objective-C++ launch code.
+
+## PyTorch and Metal integration
+
+The `.mm` file is Objective-C++, allowing the same translation unit to use the PyTorch C++ API and Apple's Metal Objective-C API.
+
+1. On the first call, `get_pipelines()` compiles the embedded `METAL_SOURCE` with `newLibraryWithSource` and creates all compute pipeline states.
+   `dispatch_once` caches them for the process lifetime.
+2. Scratch buffers are ordinary MPS tensors allocated with `at::empty`.
+   This keeps allocation and lifetime management inside PyTorch.
+3. `get_mtl_buffer()` obtains the underlying `MTLBuffer` from tensor storage, while `get_buffer_offset()` preserves a tensor's storage offset.
+4. Inputs are made contiguous before their buffers are bound, so the kernels can use linear indexing.
+5. `torch::mps::get_command_buffer()` and `get_dispatch_queue()` attach the kernels to PyTorch's current MPS stream.
+   Encoding runs under `dispatch_sync`, and `torch::mps::commit()` submits the work.
+
+The extension does not create a separate Metal device, queue, or command buffer for each operation.
+It creates a device only when compiling pipelines; execution uses PyTorch's command infrastructure.
+
+## Dispatcher and autograd
+
+`host_recur2.cpp` defines the operator schema.
+The MPS registration at the end of `lti_recur_mps_replay.mm` maps
+
+```text
+philtorch::lti_recur -> lti_recur_mps_impl
+```
+
+The public `philtorch::lti_recur` schema has a custom autograd formula in `philtorch/__init__.py`.
+Its backward pass expresses reverse recurrence using the same dispatcher operation, so MPS forward and backward both reach the replay implementation.
+
+## Why tile replay
+
+The first pass reduces each 512-element tile without writing per-element prefixes.
+After the compact tile totals are scanned, the final pass rereads the 4-byte inputs and reconstructs prefixes in registers.
+Repeating SIMD arithmetic is cheaper than writing and rereading an 8-byte `AffinePair`, and scratch remains proportional to `B * ceil((T + 1) / 512)` rather than `B * T`.
+
+## Supported inputs and edge cases
+
+The MPS implementations currently require:
+
+- `a`, `zi`, and `x` on an MPS device with the same dtype;
+- `float32` values;
+- scalar or one-dimensional `a`, containing either one value or one value per batch;
+- one-dimensional `zi` with length `B`;
+- two-dimensional `x` with shape `(B, T)`; and
+- indexing products that fit in `uint32_t`.
+
+An empty batch or zero-length sequence returns `empty_like(x)` without a Metal dispatch.
+Shared and per-batch `a` values use one kernel and a `batched_decay` flag.
+Parallel reassociation can change floating-point rounding relative to a strict serial loop, so tests use explicit `float32` tolerances.
+
+## CPU and MPS benchmark
+
+The following results were measured on an Apple M1 Pro with macOS `26.5.2`, PyTorch `2.10.0`, six CPU threads, and `float32` inputs:
+
+```bash
+pixi run python benchmarks/benchmark_mps_lti_recur.py
+```
+
+Input transfers are excluded.
+Runtime uses `torch.utils.benchmark.Timer.blocked_autorange` for at least 500 ms and reports median latency with interquartile range in parentheses.
+The MPS timer synchronizes PyTorch's MPS stream at each measurement boundary.
+CPU peak memory is reconstructed from allocation events captured by `torch.profiler.profile(profile_memory=True)`.
+Because PyTorch `2.10.0` does not expose MPS as a `ProfilerActivity`, MPS peak memory is sampled with `torch.mps.current_allocated_memory()` during repeated calls inside a profiler range.
+Memory figures exclude inputs and allocator cache but include output and native temporary tensors.
+
+| B | T | Coefficients | CPU median ms (IQR) | MPS median ms (IQR) | Speedup | CPU peak MiB | MPS peak MiB | Memory ratio |
+| ---: | ---: | :--- | ---: | ---: | ---: | ---: | ---: | ---: |
+| 1 | 4096 | shared | 0.0485 (0.0021) | 0.0274 (0.0043) | 1.77x | 0.016 | 0.016 | 0.97x |
+| 1 | 262144 | shared | 0.4403 (0.0231) | 0.0446 (0.0044) | 9.88x | 1.000 | 1.008 | 0.99x |
+| 16 | 4096 | batched | 0.1475 (0.0155) | 0.0284 (0.0056) | 5.20x | 0.500 | 0.252 | 1.98x |
+| 64 | 65536 | batched | 2.9058 (0.3561) | 0.3285 (0.0485) | 8.85x | 32.000 | 16.126 | 1.98x |
+| 256 | 4096 | batched | 1.1041 (0.2007) | 0.1365 (0.0160) | 8.09x | 8.001 | 4.035 | 1.98x |
+
+## Build and verification
+
+On macOS, `setup.py` adds every `.mm` source to the C++ extension and links the Foundation and Metal frameworks.
+The pixi environment selects Homebrew LLVM and the Homebrew OpenMP headers needed by the other native sources.
+
+Rebuild the editable extension after changing Objective-C++ or Metal source:
+
+```bash
+pixi reinstall philtorch
+```
+
+Run focused native recurrence tests with:
+
+```bash
+pixi run pytest tests/test_recur_ext.py -q
+```
+
+The MPS tests cover scalar, shared, and per-batch multipliers, empty sequences, lengths around the 512-element tile boundary, CPU/MPS device dispatch, and gradients against CPU.
+The long replay test uses `T = 512 * 512 + 1`, forcing stage 2 to carry a prefix across more than one 512-total chunk.
+
+## Invariants to preserve
+
+When modifying this implementation, keep these details synchronized:
+
+- `compose_affine(left, right)` means `right(left(h))`; do not reverse it.
+- Scan index zero is `(0, zi)`, while output index `t` reads scan index `t + 1`.
+- Missing elements in a partial tile must be `(1, 0)`.
+- `block_prefixes` is exclusive, while replayed tile-local results are inclusive.
+- The 512-element tile assumes 256 threads, two elements per thread, and eight 32-lane SIMD groups.
+- The three command encoders must remain ordered: tile reduction, block-total scan, then tile replay.
+- The only MPS registration is the public `philtorch::lti_recur` schema.

--- a/philtorch/csrc/host_lti_recur.cpp
+++ b/philtorch/csrc/host_lti_recur.cpp
@@ -48,6 +48,7 @@ at::Tensor lti_recur_cpu_impl(const at::Tensor &a,
                 "A must have the same scalar type as input");
     TORCH_CHECK(a.dim() <= 1, "A must be a vector or a scalar");
     TORCH_CHECK(zi.dim() == 1, "zi must be a vector");
+    TORCH_CHECK(x.size(1) > 0, "x must contain at least one time step");
 
     auto n_steps = x.size(1) + 1; // +1 for the initial state
     auto n_batches = x.size(0);

--- a/philtorch/csrc/lti_recur.cu
+++ b/philtorch/csrc/lti_recur.cu
@@ -119,6 +119,7 @@ at::Tensor lti_recur_cuda_impl(const at::Tensor &a,
                 "A must have the same scalar type as input");
     TORCH_CHECK(a.dim() <= 1, "A must be a vector or a scalar");
     TORCH_CHECK(zi.dim() == 1, "zi must be a vector");
+    TORCH_CHECK(x.size(1) > 0, "x must contain at least one time step");
 
     auto n_steps = x.size(1) + 1; // +1 for the initial state
     auto n_batches = x.size(0);

--- a/philtorch/csrc/lti_recur_mps_replay.mm
+++ b/philtorch/csrc/lti_recur_mps_replay.mm
@@ -1,0 +1,517 @@
+#include <torch/extension.h>
+
+#import <Foundation/Foundation.h>
+#import <Metal/Metal.h>
+
+#include <cstdint>
+#include <limits>
+
+namespace
+{
+
+constexpr const char *METAL_SOURCE = R"METAL(
+#include <metal_stdlib>
+#include <metal_simdgroup>
+using namespace metal;
+
+struct AffinePair
+{
+    float multiplier;
+    float value;
+};
+
+inline AffinePair compose_affine(AffinePair left, AffinePair right)
+{
+    AffinePair result;
+    result.multiplier = left.multiplier * right.multiplier;
+    result.value = left.value * right.multiplier + right.value;
+    return result;
+}
+
+inline AffinePair affine_identity()
+{
+    AffinePair identity;
+    identity.multiplier = 1.0f;
+    identity.value = 0.0f;
+    return identity;
+}
+
+inline AffinePair load_recurrence_pair(
+    const device float *decays,
+    const device float *initial,
+    const device float *input,
+    uint batch,
+    uint step,
+    uint sequence_length,
+    uint batched_decay)
+{
+    AffinePair pair;
+    if (step == 0)
+    {
+        pair.multiplier = 0.0f;
+        pair.value = initial[batch];
+    }
+    else if (step <= sequence_length)
+    {
+        pair.multiplier = decays[batched_decay ? batch : 0];
+        pair.value = input[batch * sequence_length + step - 1];
+    }
+    else
+    {
+        pair = affine_identity();
+    }
+    return pair;
+}
+
+inline AffinePair simd_inclusive_affine(AffinePair value, uint lane)
+{
+    for (uint offset = 1; offset < 32; offset <<= 1)
+    {
+        AffinePair left;
+        left.multiplier = simd_shuffle_up(value.multiplier, offset);
+        left.value = simd_shuffle_up(value.value, offset);
+        if (lane >= offset)
+        {
+            value = compose_affine(left, value);
+        }
+    }
+    return value;
+}
+
+kernel void replay_reduce_tiles(
+    const device float *decays [[buffer(0)]],
+    const device float *initial [[buffer(1)]],
+    const device float *input [[buffer(2)]],
+    device AffinePair *block_totals [[buffer(3)]],
+    constant uint &sequence_length [[buffer(4)]],
+    constant uint &n_tiles [[buffer(5)]],
+    constant uint &batched_decay [[buffer(6)]],
+    uint lid [[thread_index_in_threadgroup]],
+    uint lane [[thread_index_in_simdgroup]],
+    uint simd_group [[simdgroup_index_in_threadgroup]],
+    uint3 group [[threadgroup_position_in_grid]])
+{
+    constexpr uint tile_size = 512;
+    constexpr uint simd_groups = 8;
+    threadgroup AffinePair group_totals[simd_groups];
+
+    const uint tile = group.x;
+    const uint batch = group.y;
+    const uint first_step = tile * tile_size + 2 * lid;
+    const uint second_step = first_step + 1;
+    const AffinePair first = load_recurrence_pair(
+        decays, initial, input, batch, first_step,
+        sequence_length, batched_decay);
+    const AffinePair second = load_recurrence_pair(
+        decays, initial, input, batch, second_step,
+        sequence_length, batched_decay);
+    const AffinePair thread_total = compose_affine(first, second);
+    const AffinePair group_inclusive =
+        simd_inclusive_affine(thread_total, lane);
+
+    if (lane == 31)
+    {
+        group_totals[simd_group] = group_inclusive;
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    if (simd_group == 0)
+    {
+        const AffinePair group_value =
+            lane < simd_groups ? group_totals[lane] : affine_identity();
+        const AffinePair groups_inclusive =
+            simd_inclusive_affine(group_value, lane);
+        if (lane == simd_groups - 1)
+        {
+            block_totals[batch * n_tiles + tile] = groups_inclusive;
+        }
+    }
+}
+
+kernel void replay_scan_block_totals(
+    const device AffinePair *block_totals [[buffer(0)]],
+    device AffinePair *block_prefixes [[buffer(1)]],
+    constant uint &n_tiles [[buffer(2)]],
+    uint lid [[thread_index_in_threadgroup]],
+    uint lane [[thread_index_in_simdgroup]],
+    uint simd_group [[simdgroup_index_in_threadgroup]],
+    uint3 group [[threadgroup_position_in_grid]])
+{
+    constexpr uint tile_size = 512;
+    constexpr uint simd_groups = 8;
+    threadgroup AffinePair group_totals[simd_groups];
+    threadgroup AffinePair group_prefixes[simd_groups];
+    threadgroup AffinePair carry;
+
+    const uint batch = group.x;
+    const uint n_chunks = (n_tiles - 1) / tile_size + 1;
+    if (lid == 0)
+    {
+        carry = affine_identity();
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    for (uint chunk = 0; chunk < n_chunks; ++chunk)
+    {
+        const uint first_tile = chunk * tile_size + 2 * lid;
+        const uint second_tile = first_tile + 1;
+        const AffinePair first = first_tile < n_tiles
+            ? block_totals[batch * n_tiles + first_tile]
+            : affine_identity();
+        const AffinePair second = second_tile < n_tiles
+            ? block_totals[batch * n_tiles + second_tile]
+            : affine_identity();
+        const AffinePair thread_total = compose_affine(first, second);
+        const AffinePair group_inclusive =
+            simd_inclusive_affine(thread_total, lane);
+
+        if (lane == 31)
+        {
+            group_totals[simd_group] = group_inclusive;
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        if (simd_group == 0)
+        {
+            const AffinePair group_value =
+                lane < simd_groups ? group_totals[lane] : affine_identity();
+            const AffinePair groups_inclusive =
+                simd_inclusive_affine(group_value, lane);
+            AffinePair prior_group;
+            prior_group.multiplier = simd_shuffle_up(
+                groups_inclusive.multiplier, 1);
+            prior_group.value = simd_shuffle_up(groups_inclusive.value, 1);
+            if (lane < simd_groups)
+            {
+                group_prefixes[lane] =
+                    lane == 0 ? affine_identity() : prior_group;
+            }
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        AffinePair prior_thread;
+        prior_thread.multiplier = simd_shuffle_up(
+            group_inclusive.multiplier, 1);
+        prior_thread.value = simd_shuffle_up(group_inclusive.value, 1);
+        const AffinePair local_prefix = compose_affine(
+            group_prefixes[simd_group],
+            lane == 0 ? affine_identity() : prior_thread);
+        const AffinePair chunk_prefix = carry;
+        const AffinePair first_prefix =
+            compose_affine(chunk_prefix, local_prefix);
+        const AffinePair first_inclusive = compose_affine(first_prefix, first);
+        const AffinePair second_inclusive =
+            compose_affine(first_inclusive, second);
+
+        if (first_tile < n_tiles)
+        {
+            block_prefixes[batch * n_tiles + first_tile] = first_prefix;
+        }
+        if (second_tile < n_tiles)
+        {
+            block_prefixes[batch * n_tiles + second_tile] = first_inclusive;
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        if (lid == 255)
+        {
+            carry = second_inclusive;
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+}
+
+kernel void replay_scan_tiles(
+    const device float *decays [[buffer(0)]],
+    const device float *initial [[buffer(1)]],
+    const device float *input [[buffer(2)]],
+    const device AffinePair *block_prefixes [[buffer(3)]],
+    device float *output [[buffer(4)]],
+    constant uint &sequence_length [[buffer(5)]],
+    constant uint &n_tiles [[buffer(6)]],
+    constant uint &batched_decay [[buffer(7)]],
+    uint lid [[thread_index_in_threadgroup]],
+    uint lane [[thread_index_in_simdgroup]],
+    uint simd_group [[simdgroup_index_in_threadgroup]],
+    uint3 group [[threadgroup_position_in_grid]])
+{
+    constexpr uint tile_size = 512;
+    constexpr uint simd_groups = 8;
+    threadgroup AffinePair group_totals[simd_groups];
+    threadgroup AffinePair group_prefixes[simd_groups];
+    threadgroup AffinePair tile_prefix;
+
+    const uint tile = group.x;
+    const uint batch = group.y;
+    const uint first_step = tile * tile_size + 2 * lid;
+    const uint second_step = first_step + 1;
+    const AffinePair first = load_recurrence_pair(
+        decays, initial, input, batch, first_step,
+        sequence_length, batched_decay);
+    const AffinePair second = load_recurrence_pair(
+        decays, initial, input, batch, second_step,
+        sequence_length, batched_decay);
+    const AffinePair thread_total = compose_affine(first, second);
+    const AffinePair group_inclusive =
+        simd_inclusive_affine(thread_total, lane);
+
+    if (lane == 31)
+    {
+        group_totals[simd_group] = group_inclusive;
+    }
+    if (lid == 0)
+    {
+        tile_prefix = block_prefixes[batch * n_tiles + tile];
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    if (simd_group == 0)
+    {
+        const AffinePair group_value =
+            lane < simd_groups ? group_totals[lane] : affine_identity();
+        const AffinePair groups_inclusive =
+            simd_inclusive_affine(group_value, lane);
+        AffinePair prior_group;
+        prior_group.multiplier = simd_shuffle_up(
+            groups_inclusive.multiplier, 1);
+        prior_group.value = simd_shuffle_up(groups_inclusive.value, 1);
+        if (lane < simd_groups)
+        {
+            group_prefixes[lane] =
+                lane == 0 ? affine_identity() : prior_group;
+        }
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    AffinePair prior_thread;
+    prior_thread.multiplier = simd_shuffle_up(
+        group_inclusive.multiplier, 1);
+    prior_thread.value = simd_shuffle_up(group_inclusive.value, 1);
+    const AffinePair thread_prefix = compose_affine(
+        group_prefixes[simd_group],
+        lane == 0 ? affine_identity() : prior_thread);
+    const AffinePair first_inclusive = compose_affine(thread_prefix, first);
+    const AffinePair second_inclusive = compose_affine(first_inclusive, second);
+
+    if (first_step > 0 && first_step <= sequence_length)
+    {
+        output[batch * sequence_length + first_step - 1] =
+            compose_affine(tile_prefix, first_inclusive).value;
+    }
+    if (second_step <= sequence_length)
+    {
+        output[batch * sequence_length + second_step - 1] =
+            compose_affine(tile_prefix, second_inclusive).value;
+    }
+}
+)METAL";
+
+struct MetalPipelines
+{
+    id<MTLComputePipelineState> reduce_tiles;
+    id<MTLComputePipelineState> scan_block_totals;
+    id<MTLComputePipelineState> scan_tiles;
+};
+
+id<MTLBuffer> get_mtl_buffer(const at::Tensor &tensor)
+{
+    return __builtin_bit_cast(id<MTLBuffer>, tensor.storage().data());
+}
+
+NSUInteger get_buffer_offset(const at::Tensor &tensor)
+{
+    return static_cast<NSUInteger>(tensor.storage_offset() * tensor.element_size());
+}
+
+MetalPipelines &get_pipelines()
+{
+    static MetalPipelines pipelines;
+    static dispatch_once_t once_token;
+    dispatch_once(&once_token, ^{
+      id<MTLDevice> device = MTLCreateSystemDefaultDevice();
+      TORCH_CHECK(device, "Failed to find a Metal device");
+
+      NSError *error = nil;
+      NSString *source = [NSString stringWithUTF8String:METAL_SOURCE];
+      id<MTLLibrary> library = [device newLibraryWithSource:source
+                                                    options:nil
+                                                      error:&error];
+      TORCH_CHECK(library, "Failed to compile scalar recurrence Metal kernels: ",
+                  error.localizedDescription.UTF8String);
+
+      id<MTLFunction> reduce_tiles_function =
+          [library newFunctionWithName:@"replay_reduce_tiles"];
+      id<MTLFunction> scan_block_totals_function =
+          [library newFunctionWithName:@"replay_scan_block_totals"];
+      id<MTLFunction> scan_tiles_function =
+          [library newFunctionWithName:@"replay_scan_tiles"];
+      TORCH_CHECK(reduce_tiles_function && scan_block_totals_function &&
+                      scan_tiles_function,
+                  "Failed to load scalar recurrence Metal functions");
+
+      pipelines.reduce_tiles =
+          [device newComputePipelineStateWithFunction:reduce_tiles_function
+                                                error:&error];
+      TORCH_CHECK(pipelines.reduce_tiles,
+                  "Failed to create tile reduction pipeline: ",
+                  error.localizedDescription.UTF8String);
+      pipelines.scan_block_totals =
+          [device newComputePipelineStateWithFunction:scan_block_totals_function
+                                                error:&error];
+      TORCH_CHECK(pipelines.scan_block_totals,
+                  "Failed to create block-total scan pipeline: ",
+                  error.localizedDescription.UTF8String);
+      pipelines.scan_tiles =
+          [device newComputePipelineStateWithFunction:scan_tiles_function
+                                                error:&error];
+      TORCH_CHECK(pipelines.scan_tiles,
+                  "Failed to create tile replay pipeline: ",
+                  error.localizedDescription.UTF8String);
+    });
+    return pipelines;
+}
+
+at::Tensor lti_recur_mps_impl(const at::Tensor &a, const at::Tensor &zi,
+                              const at::Tensor &x)
+{
+    TORCH_CHECK(a.device().is_mps() && zi.device().is_mps() && x.device().is_mps(),
+                "a, zi, and x must be MPS tensors");
+    TORCH_CHECK(a.scalar_type() == x.scalar_type() &&
+                    zi.scalar_type() == x.scalar_type(),
+                "a, zi, and x must have the same scalar type");
+    TORCH_CHECK(x.scalar_type() == at::kFloat,
+                "MPS scalar recurrence currently supports float32 only");
+    TORCH_CHECK(a.dim() <= 1, "a must be a vector or a scalar");
+    TORCH_CHECK(zi.dim() == 1, "zi must be a vector");
+    TORCH_CHECK(x.dim() == 2, "x must be a matrix");
+    TORCH_CHECK(zi.size(0) == x.size(0),
+                "zi and x must have the same batch size");
+    TORCH_CHECK(a.numel() == 1 || a.numel() == x.size(0),
+                "a must contain one value or one value per batch");
+
+    const int64_t n_batches_64 = x.size(0);
+    const int64_t sequence_length_64 = x.size(1);
+    if (n_batches_64 == 0 || sequence_length_64 == 0)
+    {
+        return at::empty_like(x);
+    }
+
+    constexpr uint64_t tile_size = 512;
+    const uint64_t n_steps_wide = static_cast<uint64_t>(sequence_length_64) + 1;
+    const uint64_t n_tiles_wide = (n_steps_wide - 1) / tile_size + 1;
+    TORCH_CHECK(n_steps_wide <= std::numeric_limits<uint32_t>::max() &&
+                    n_tiles_wide <= std::numeric_limits<uint32_t>::max() &&
+                    static_cast<uint64_t>(n_batches_64) * n_tiles_wide <=
+                        std::numeric_limits<uint32_t>::max() &&
+                    static_cast<uint64_t>(n_batches_64) * sequence_length_64 <=
+                        std::numeric_limits<uint32_t>::max(),
+                "MPS scalar recurrence input is too large");
+
+    const uint32_t n_batches = static_cast<uint32_t>(n_batches_64);
+    const uint32_t n_tiles = static_cast<uint32_t>(n_tiles_wide);
+    const uint32_t sequence_length = static_cast<uint32_t>(sequence_length_64);
+    const uint32_t batched_decay = a.numel() == n_batches_64 ? 1 : 0;
+    const auto a_contiguous = a.contiguous();
+    const auto zi_contiguous = zi.contiguous();
+    const auto x_contiguous = x.contiguous();
+    auto block_totals = at::empty(
+        {n_batches_64, static_cast<int64_t>(n_tiles), 2}, x.options());
+    auto block_prefixes = at::empty_like(block_totals);
+    auto output = at::empty_like(x_contiguous);
+    auto &pipelines = get_pipelines();
+    constexpr NSUInteger threads_per_group = 256;
+    TORCH_CHECK(pipelines.reduce_tiles.threadExecutionWidth == 32 &&
+                    pipelines.scan_block_totals.threadExecutionWidth == 32 &&
+                    pipelines.scan_tiles.threadExecutionWidth == 32,
+                "MPS scalar recurrence requires 32-lane SIMD groups");
+    TORCH_CHECK(
+        pipelines.reduce_tiles.maxTotalThreadsPerThreadgroup >= threads_per_group &&
+            pipelines.scan_block_totals.maxTotalThreadsPerThreadgroup >=
+                threads_per_group &&
+            pipelines.scan_tiles.maxTotalThreadsPerThreadgroup >= threads_per_group,
+        "Metal device does not support the scalar recurrence threadgroup size");
+
+    id<MTLCommandBuffer> command_buffer = torch::mps::get_command_buffer();
+    TORCH_CHECK(command_buffer, "Failed to retrieve the MPS command buffer");
+    dispatch_queue_t queue = torch::mps::get_dispatch_queue();
+
+    dispatch_sync(queue, ^{
+      id<MTLComputeCommandEncoder> encoder = [command_buffer computeCommandEncoder];
+      TORCH_CHECK(encoder, "Failed to create the tile reduction encoder");
+      [encoder setComputePipelineState:pipelines.reduce_tiles];
+      [encoder setBuffer:get_mtl_buffer(a_contiguous)
+                   offset:get_buffer_offset(a_contiguous)
+                  atIndex:0];
+      [encoder setBuffer:get_mtl_buffer(zi_contiguous)
+                   offset:get_buffer_offset(zi_contiguous)
+                  atIndex:1];
+      [encoder setBuffer:get_mtl_buffer(x_contiguous)
+                   offset:get_buffer_offset(x_contiguous)
+                  atIndex:2];
+      [encoder setBuffer:get_mtl_buffer(block_totals)
+                   offset:get_buffer_offset(block_totals)
+                  atIndex:3];
+      [encoder setBytes:&sequence_length
+                  length:sizeof(sequence_length)
+                 atIndex:4];
+      [encoder setBytes:&n_tiles length:sizeof(n_tiles) atIndex:5];
+      [encoder setBytes:&batched_decay
+                  length:sizeof(batched_decay)
+                 atIndex:6];
+      [encoder dispatchThreadgroups:MTLSizeMake(n_tiles, n_batches, 1)
+                 threadsPerThreadgroup:MTLSizeMake(threads_per_group, 1, 1)];
+      [encoder endEncoding];
+
+      encoder = [command_buffer computeCommandEncoder];
+      TORCH_CHECK(encoder, "Failed to create the block-total scan encoder");
+      [encoder setComputePipelineState:pipelines.scan_block_totals];
+      [encoder setBuffer:get_mtl_buffer(block_totals)
+                   offset:get_buffer_offset(block_totals)
+                  atIndex:0];
+      [encoder setBuffer:get_mtl_buffer(block_prefixes)
+                   offset:get_buffer_offset(block_prefixes)
+                  atIndex:1];
+      [encoder setBytes:&n_tiles length:sizeof(n_tiles) atIndex:2];
+      [encoder dispatchThreadgroups:MTLSizeMake(n_batches, 1, 1)
+                 threadsPerThreadgroup:MTLSizeMake(threads_per_group, 1, 1)];
+      [encoder endEncoding];
+
+      encoder = [command_buffer computeCommandEncoder];
+      TORCH_CHECK(encoder, "Failed to create the tile replay encoder");
+      [encoder setComputePipelineState:pipelines.scan_tiles];
+      [encoder setBuffer:get_mtl_buffer(a_contiguous)
+                   offset:get_buffer_offset(a_contiguous)
+                  atIndex:0];
+      [encoder setBuffer:get_mtl_buffer(zi_contiguous)
+                   offset:get_buffer_offset(zi_contiguous)
+                  atIndex:1];
+      [encoder setBuffer:get_mtl_buffer(x_contiguous)
+                   offset:get_buffer_offset(x_contiguous)
+                  atIndex:2];
+      [encoder setBuffer:get_mtl_buffer(block_prefixes)
+                   offset:get_buffer_offset(block_prefixes)
+                  atIndex:3];
+      [encoder setBuffer:get_mtl_buffer(output)
+                   offset:get_buffer_offset(output)
+                  atIndex:4];
+      [encoder setBytes:&sequence_length
+                  length:sizeof(sequence_length)
+                 atIndex:5];
+      [encoder setBytes:&n_tiles length:sizeof(n_tiles) atIndex:6];
+      [encoder setBytes:&batched_decay
+                  length:sizeof(batched_decay)
+                 atIndex:7];
+      [encoder dispatchThreadgroups:MTLSizeMake(n_tiles, n_batches, 1)
+                 threadsPerThreadgroup:MTLSizeMake(threads_per_group, 1, 1)];
+      [encoder endEncoding];
+      torch::mps::commit();
+    });
+
+    return output;
+}
+
+} // namespace
+
+TORCH_LIBRARY_IMPL(philtorch, MPS, m)
+{
+    m.impl("lti_recur", &lti_recur_mps_impl);
+}

--- a/philtorch/csrc/lti_recur_mps_replay.mm
+++ b/philtorch/csrc/lti_recur_mps_replay.mm
@@ -387,10 +387,11 @@ at::Tensor lti_recur_mps_impl(const at::Tensor &a, const at::Tensor &zi,
                 "zi and x must have the same batch size");
     TORCH_CHECK(a.numel() == 1 || a.numel() == x.size(0),
                 "a must contain one value or one value per batch");
+    TORCH_CHECK(x.size(1) > 0, "x must contain at least one time step");
 
     const int64_t n_batches_64 = x.size(0);
     const int64_t sequence_length_64 = x.size(1);
-    if (n_batches_64 == 0 || sequence_length_64 == 0)
+    if (n_batches_64 == 0)
     {
         return at::empty_like(x);
     }

--- a/pixi.lock
+++ b/pixi.lock
@@ -438,6 +438,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/babel-2.18.0-pyhcf101f3_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/backports.zstd-1.5.0-py314h680f03e_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/beautifulsoup4-4.14.3-pyha770c72_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/black-26.5.1-pyh866005b_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/bleach-6.3.0-pyhcf101f3_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/bleach-with-css-6.3.0-hbca2aae_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.4.22-hbd8a1cb_0.conda
@@ -445,6 +446,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
       - conda: https://prefix.dev/conda-forge/noarch/certifi-2026.4.22-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/charset-normalizer-3.4.7-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/click-8.4.2-pyhc90fa1f_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/comm-0.2.3-pyhe01879c_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/cpython-3.14.4-py314hd8ed1ab_100.conda
@@ -496,6 +498,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/mistune-3.2.1-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/mpmath-1.3.0-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/nbclient-0.10.4-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/nbconvert-core-7.17.1-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_1.conda
@@ -508,6 +511,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/packaging-26.2-pyhc364b38_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://prefix.dev/conda-forge/noarch/parso-0.8.7-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pathspec-1.1.1-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/platformdirs-4.9.6-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
@@ -629,6 +633,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/pyobjc-core-12.1-py314h3a4d195_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/pyobjc-framework-cocoa-12.1-py314h36abed7_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/python-3.14.4-h4c637c5_100_cp314.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/pytokens-0.4.1-py314ha14b1ff_2.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/pytorch-2.10.0-cpu_generic_py314_he36690f_3.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/pytorch-cpu-2.10.0-cpu_generic_hcc7c195_3.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/pyyaml-6.0.3-py314h6e9b3f0_1.conda
@@ -4379,6 +4384,24 @@ packages:
   - pkg:pypi/beautifulsoup4?source=hash-mapping
   size: 90399
   timestamp: 1764520638652
+- conda: https://prefix.dev/conda-forge/noarch/black-26.5.1-pyh866005b_0.conda
+  sha256: f194e91242b26a7fd2244bf0ab0acb59c3f20ecbfe81d095d753e9183defbfb7
+  md5: 651a8c2065be6883e86ec0e8471ed5ce
+  depends:
+  - click >=8.0.0
+  - mypy_extensions >=0.4.3
+  - packaging >=22.0
+  - pathspec >=0.9
+  - platformdirs >=2
+  - python >=3.11
+  - pytokens >=0.4
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/black?source=hash-mapping
+  run_exports: {}
+  size: 176838
+  timestamp: 1779460936776
 - conda: https://prefix.dev/conda-forge/noarch/bleach-6.3.0-pyhcf101f3_0.conda
   sha256: e03ba1a2b93fe0383c57920a9dc6b4e0c2c7972a3f214d531ed3c21dc8f8c717
   md5: b1a27250d70881943cca0dd6b4ba0956
@@ -4509,6 +4532,20 @@ packages:
   - pkg:pypi/charset-normalizer?source=hash-mapping
   size: 58872
   timestamp: 1775127203018
+- conda: https://prefix.dev/conda-forge/noarch/click-8.4.2-pyhc90fa1f_0.conda
+  sha256: ccc4787f511964f9a1f2d2d2859c91c5d571fb60f7f09d4c4e092c9b7a94e671
+  md5: 2c4bd6aeb90bb157456841c3270a0d92
+  depends:
+  - __unix
+  - python
+  - python >=3.10
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/click?source=hash-mapping
+  run_exports: {}
+  size: 107155
+  timestamp: 1783085363526
 - conda: https://prefix.dev/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
   sha256: ab29d57dc70786c1269633ba3dff20288b81664d3ff8d21af995742e2bb03287
   md5: 962b9857ee8e7018c22f2776ffa0b2d7
@@ -5804,6 +5841,18 @@ packages:
   - pkg:pypi/munkres?source=hash-mapping
   size: 15851
   timestamp: 1749895533014
+- conda: https://prefix.dev/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
+  sha256: 6ed158e4e5dd8f6a10ad9e525631e35cee8557718f83de7a4e3966b1f772c4b1
+  md5: e9c622e0d00fa24a6292279af3ab6d06
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/mypy-extensions?source=hash-mapping
+  run_exports: {}
+  size: 11766
+  timestamp: 1745776666688
 - conda: https://prefix.dev/conda-forge/noarch/nbclient-0.10.2-pyhd8ed1ab_0.conda
   sha256: a20cff739d66c2f89f413e4ba4c6f6b59c50d5c30b5f0d840c13e8c9c2df9135
   md5: 6bb0d77277061742744176ab555b723c
@@ -6066,6 +6115,18 @@ packages:
   - pkg:pypi/parso?source=hash-mapping
   size: 82472
   timestamp: 1777722955579
+- conda: https://prefix.dev/conda-forge/noarch/pathspec-1.1.1-pyhd8ed1ab_0.conda
+  sha256: 6eaee417d33f298db79bc7185ab1208604c0e6cf51dade34cd513c6f9db9c6f3
+  md5: 11adc78451c998c0fd162584abfa3559
+  depends:
+  - python >=3.10
+  license: MPL-2.0
+  license_family: MOZILLA
+  purls:
+  - pkg:pypi/pathspec?source=hash-mapping
+  run_exports: {}
+  size: 56559
+  timestamp: 1777271601895
 - conda: https://prefix.dev/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_1.conda
   sha256: 202af1de83b585d36445dc1fda94266697341994d1a3328fabde4989e1b3d07a
   md5: d0d408b1f18883a944376da5cf8101ea
@@ -7960,6 +8021,21 @@ packages:
   size: 13533346
   timestamp: 1775616188373
   python_site_packages_path: lib/python3.14/site-packages
+- conda: https://prefix.dev/conda-forge/osx-arm64/pytokens-0.4.1-py314ha14b1ff_2.conda
+  sha256: 37d76254955eaa47df534ae8f3890c45f28aa4a8479597ff6fbacbd5a23810e6
+  md5: 45bfaa1961db6ace6fc35561ba893fae
+  depends:
+  - python
+  - __osx >=11.0
+  - python 3.14.* *_cp314
+  - python_abi 3.14.* *_cp314
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/pytokens?source=hash-mapping
+  run_exports: {}
+  size: 175381
+  timestamp: 1778689065100
 - conda: https://prefix.dev/conda-forge/osx-arm64/pytorch-2.10.0-cpu_generic_py314_he36690f_3.conda
   sha256: f4badf8ef7a8bfa5619807e04e30e425da80c9c717e97ad0702c88e774a89532
   md5: 51da3d684a7d90b35adfd742fb551cc4

--- a/pixi.toml
+++ b/pixi.toml
@@ -33,7 +33,12 @@ pararnn = { git = "https://github.com/yoyolicoris/ml-pararnn.git", rev = "29299d
 cuda = "13.0"
 
 [target.osx-arm64.dependencies]
+black = ">=26.1.0,<27"
 pytorch-cpu = ">=2.9.1,<3"
+
+[target.osx-arm64.activation.env]
+CXX = "/opt/homebrew/opt/llvm/bin/clang++"
+CPPFLAGS = "-I/opt/homebrew/opt/libomp/include"
 
 [pypi-options]
 no-build-isolation = true

--- a/pixi.toml
+++ b/pixi.toml
@@ -36,9 +36,5 @@ cuda = "13.0"
 black = ">=26.1.0,<27"
 pytorch-cpu = ">=2.9.1,<3"
 
-[target.osx-arm64.activation.env]
-CXX = "/opt/homebrew/opt/llvm/bin/clang++"
-CPPFLAGS = "-I/opt/homebrew/opt/libomp/include"
-
 [pypi-options]
 no-build-isolation = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,3 +71,6 @@ markers = [
     "integration: marks tests as integration tests",
     "unit: marks tests as unit tests",
 ]
+
+[tool.black]
+target-version = ["py310"]

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,10 @@ def get_extensions():
     sources = list(glob.glob(os.path.join(extensions_dir, "*.cpp")))
     cuda_sources = list(glob.glob(os.path.join(extensions_dir, "*.cu")))
 
+    if sys.platform == "darwin":
+        sources += list(glob.glob(os.path.join(extensions_dir, "*.mm")))
+        extra_link_args.extend(["-framework", "Foundation", "-framework", "Metal"])
+
     if use_cuda:
         sources += cuda_sources
         extra_compile_args["nvcc"] = ["--extended-lambda"]

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ def get_homebrew_prefix(formula):
     return result.stdout.strip()
 
 
-def configure_macos_openmp(extra_compile_args, extra_link_args):
+def get_macos_openmp_config(extra_compile_args, extra_link_args):
     llvm_prefix = get_homebrew_prefix("llvm")
     libomp_prefix = get_homebrew_prefix("libomp")
     compiler = os.path.join(llvm_prefix, "bin", "clang++")
@@ -55,14 +55,16 @@ def configure_macos_openmp(extra_compile_args, extra_link_args):
             + ", ".join(missing_paths)
         )
 
-    os.environ.setdefault("CXX", compiler)
-    extra_compile_args["cxx"].append(f"-I{include_dir}")
-    extra_link_args.extend(
-        [
-            f"-L{library_dir}",
-            f"-Wl,-rpath,{library_dir}",
-        ]
-    )
+    configured_compile_args = {
+        **extra_compile_args,
+        "cxx": [*extra_compile_args.get("cxx", ()), f"-I{include_dir}"],
+    }
+    configured_link_args = [
+        *extra_link_args,
+        f"-L{library_dir}",
+        f"-Wl,-rpath,{library_dir}",
+    ]
+    return compiler, configured_compile_args, configured_link_args
 
 
 def get_extensions():
@@ -76,7 +78,10 @@ def get_extensions():
         extra_compile_args["cxx"] = ["-fopenmp"]
         extra_link_args.append("-fopenmp")
         if sys.platform == "darwin":
-            configure_macos_openmp(extra_compile_args, extra_link_args)
+            compiler, extra_compile_args, extra_link_args = get_macos_openmp_config(
+                extra_compile_args, extra_link_args
+            )
+            os.environ.setdefault("CXX", compiler)
             torch_lib = os.path.join(os.path.dirname(torch.__file__), "lib")
             if os.path.isdir(torch_lib):
                 extra_link_args.extend(

--- a/setup.py
+++ b/setup.py
@@ -36,22 +36,21 @@ def get_homebrew_prefix(formula):
     return result.stdout.strip()
 
 
-def get_macos_openmp_config(extra_compile_args, extra_link_args):
+def get_macos_openmp_config(extra_compile_args, extra_link_args, torch_lib):
     llvm_prefix = get_homebrew_prefix("llvm")
     libomp_prefix = get_homebrew_prefix("libomp")
     compiler = os.path.join(llvm_prefix, "bin", "clang++")
     include_dir = os.path.join(libomp_prefix, "include")
-    library_dir = os.path.join(libomp_prefix, "lib")
 
     required_paths = (
         compiler,
         os.path.join(include_dir, "omp.h"),
-        os.path.join(library_dir, "libomp.dylib"),
+        os.path.join(torch_lib, "libomp.dylib"),
     )
     missing_paths = [path for path in required_paths if not os.path.isfile(path)]
     if missing_paths:
         raise RuntimeError(
-            "Homebrew LLVM/OpenMP installation is incomplete; missing: "
+            "macOS OpenMP build dependencies are incomplete; missing: "
             + ", ".join(missing_paths)
         )
 
@@ -61,8 +60,8 @@ def get_macos_openmp_config(extra_compile_args, extra_link_args):
     }
     configured_link_args = [
         *extra_link_args,
-        f"-L{library_dir}",
-        f"-Wl,-rpath,{library_dir}",
+        f"-L{torch_lib}",
+        f"-Wl,-rpath,{torch_lib}",
     ]
     return compiler, configured_compile_args, configured_link_args
 
@@ -78,18 +77,11 @@ def get_extensions():
         extra_compile_args["cxx"] = ["-fopenmp"]
         extra_link_args.append("-fopenmp")
         if sys.platform == "darwin":
+            torch_lib = os.path.join(os.path.dirname(torch.__file__), "lib")
             compiler, extra_compile_args, extra_link_args = get_macos_openmp_config(
-                extra_compile_args, extra_link_args
+                extra_compile_args, extra_link_args, torch_lib
             )
             os.environ.setdefault("CXX", compiler)
-            torch_lib = os.path.join(os.path.dirname(torch.__file__), "lib")
-            if os.path.isdir(torch_lib):
-                extra_link_args.extend(
-                    [
-                        f"-L{torch_lib}",
-                        f"-Wl,-rpath,{torch_lib}",
-                    ]
-                )
 
     this_dir = os.path.abspath(os.path.dirname(__file__))
     extensions_dir = os.path.join(this_dir, library_name, "csrc")

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 from setuptools import setup
 import os
 import glob
+import subprocess
 import sys
 import torch
 from torch.utils.cpp_extension import (
@@ -11,6 +12,57 @@ from torch.utils.cpp_extension import (
 )
 
 library_name = "philtorch"
+
+
+def get_homebrew_prefix(formula):
+    try:
+        result = subprocess.run(
+            ["brew", "--prefix", formula],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError as error:
+        raise RuntimeError(
+            "Homebrew is required for macOS OpenMP builds; "
+            "install Homebrew, then run 'brew install llvm libomp'."
+        ) from error
+    except subprocess.CalledProcessError as error:
+        raise RuntimeError(
+            f"Homebrew formula '{formula}' is required for macOS OpenMP builds; "
+            "install it with 'brew install llvm libomp'."
+        ) from error
+
+    return result.stdout.strip()
+
+
+def configure_macos_openmp(extra_compile_args, extra_link_args):
+    llvm_prefix = get_homebrew_prefix("llvm")
+    libomp_prefix = get_homebrew_prefix("libomp")
+    compiler = os.path.join(llvm_prefix, "bin", "clang++")
+    include_dir = os.path.join(libomp_prefix, "include")
+    library_dir = os.path.join(libomp_prefix, "lib")
+
+    required_paths = (
+        compiler,
+        os.path.join(include_dir, "omp.h"),
+        os.path.join(library_dir, "libomp.dylib"),
+    )
+    missing_paths = [path for path in required_paths if not os.path.isfile(path)]
+    if missing_paths:
+        raise RuntimeError(
+            "Homebrew LLVM/OpenMP installation is incomplete; missing: "
+            + ", ".join(missing_paths)
+        )
+
+    os.environ.setdefault("CXX", compiler)
+    extra_compile_args["cxx"].append(f"-I{include_dir}")
+    extra_link_args.extend(
+        [
+            f"-L{library_dir}",
+            f"-Wl,-rpath,{library_dir}",
+        ]
+    )
 
 
 def get_extensions():
@@ -24,6 +76,7 @@ def get_extensions():
         extra_compile_args["cxx"] = ["-fopenmp"]
         extra_link_args.append("-fopenmp")
         if sys.platform == "darwin":
+            configure_macos_openmp(extra_compile_args, extra_link_args)
             torch_lib = os.path.join(os.path.dirname(torch.__file__), "lib")
             if os.path.isdir(torch_lib):
                 extra_link_args.extend(

--- a/tests/test_recur_ext.py
+++ b/tests/test_recur_ext.py
@@ -103,10 +103,38 @@ def test_lti_recur_equiv(device: str, batch: bool):
     torch.testing.assert_close(lti_y, torch_y)
 
 
+@pytest.mark.parametrize(
+    "device",
+    [
+        "cpu",
+        "meta",
+        pytest.param(
+            "cuda",
+            marks=pytest.mark.skipif(
+                not torch.cuda.is_available(), reason="CUDA not available"
+            ),
+        ),
+        pytest.param(
+            "mps",
+            marks=pytest.mark.skipif(
+                not torch.backends.mps.is_available(), reason="MPS not available"
+            ),
+        ),
+    ],
+)
+def test_lti_recur_rejects_zero_length(device: str):
+    a = torch.empty(1, device=device)
+    zi = torch.empty(2, device=device)
+    x = torch.empty(2, 0, device=device)
+
+    with pytest.raises(RuntimeError, match="at least one time step"):
+        torch.ops.philtorch.lti_recur(a, zi, x)
+
+
 @pytest.mark.skipif(not torch.backends.mps.is_available(), reason="MPS not available")
 @pytest.mark.parametrize("coefficient_layout", ["scalar", "shared", "batched"])
 @pytest.mark.parametrize(
-    "samples", [0, 1, 2, 3, 7, 8, 15, 16, 17, 257, 511, 512, 513, 1234]
+    "samples", [1, 2, 3, 7, 8, 15, 16, 17, 257, 511, 512, 513, 1234]
 )
 def test_lti_recur_mps_boundaries(coefficient_layout: str, samples: int):
     batch_size = 3

--- a/tests/test_recur_ext.py
+++ b/tests/test_recur_ext.py
@@ -79,21 +79,89 @@ def test_lti_recurN_equiv(device: str, batch: bool, order: int):
                 not torch.cuda.is_available(), reason="CUDA not available"
             ),
         ),
+        pytest.param(
+            "mps",
+            marks=pytest.mark.skipif(
+                not torch.backends.mps.is_available(), reason="MPS not available"
+            ),
+        ),
     ],
 )
 @pytest.mark.parametrize("batch", [True, False])
 def test_lti_recur_equiv(device: str, batch: bool):
     B = 3
     T = 101
+    dtype = torch.float32 if device == "mps" else torch.float64
 
     # Convert to torch tensors
-    a_torch = torch.rand(B if batch else 1).to(device).double() * 2 - 1
-    x_torch = torch.randn(B, T).to(device).double()
+    a_torch = torch.rand(B if batch else 1, device=device, dtype=dtype) * 2 - 1
+    x_torch = torch.randn(B, T, device=device, dtype=dtype)
     zi = x_torch.new_zeros(B).normal_()
 
     lti_y = torch.ops.philtorch.lti_recur(a_torch, zi, x_torch)
     torch_y = linear_recurrence(a_torch, zi, x_torch)
-    assert torch.allclose(lti_y, torch_y), torch.max(torch.abs(lti_y - torch_y))
+    torch.testing.assert_close(lti_y, torch_y)
+
+
+@pytest.mark.skipif(not torch.backends.mps.is_available(), reason="MPS not available")
+@pytest.mark.parametrize("coefficient_layout", ["scalar", "shared", "batched"])
+@pytest.mark.parametrize(
+    "samples", [0, 1, 2, 3, 7, 8, 15, 16, 17, 257, 511, 512, 513, 1234]
+)
+def test_lti_recur_mps_boundaries(coefficient_layout: str, samples: int):
+    batch_size = 3
+    coefficient_shape = {
+        "scalar": (),
+        "shared": (1,),
+        "batched": (batch_size,),
+    }[coefficient_layout]
+    a = torch.rand(coefficient_shape, dtype=torch.float32) * 1.5 - 0.75
+    zi = torch.randn(batch_size, dtype=torch.float32)
+    x = torch.randn(batch_size, samples, dtype=torch.float32)
+
+    expected = torch.ops.philtorch.lti_recur(a, zi, x)
+    actual = torch.ops.philtorch.lti_recur(a.to("mps"), zi.to("mps"), x.to("mps")).cpu()
+    torch.testing.assert_close(actual, expected, rtol=1e-5, atol=1e-6)
+
+
+@pytest.mark.skipif(not torch.backends.mps.is_available(), reason="MPS not available")
+def test_lti_recur_mps_block_chunks():
+    samples = 512 * 512 + 1
+    a = torch.tensor([0.25], dtype=torch.float32)
+    zi = torch.randn(1, dtype=torch.float32)
+    x = torch.randn(1, samples, dtype=torch.float32)
+
+    expected = torch.ops.philtorch.lti_recur(a, zi, x)
+    actual = torch.ops.philtorch.lti_recur(a.to("mps"), zi.to("mps"), x.to("mps")).cpu()
+    torch.testing.assert_close(actual, expected, rtol=1e-5, atol=1e-6)
+
+
+@pytest.mark.skipif(not torch.backends.mps.is_available(), reason="MPS not available")
+@pytest.mark.parametrize("batch_decay", [True, False])
+def test_lti_recur_mps_grad_equiv(batch_decay: bool):
+    batch_size = 3
+    samples = 17
+    a = torch.rand(batch_size if batch_decay else 1, dtype=torch.float32) * 0.75 - 0.375
+    zi = torch.randn(batch_size, dtype=torch.float32)
+    x = torch.randn(batch_size, samples, dtype=torch.float32)
+    grad_output = torch.randn_like(x)
+
+    def run(device: str):
+        device_inputs = tuple(
+            value.to(device).detach().requires_grad_() for value in (a, zi, x)
+        )
+        output = torch.ops.philtorch.lti_recur(*device_inputs)
+        gradients = torch.autograd.grad(
+            output, device_inputs, grad_outputs=grad_output.to(device)
+        )
+        return output.detach().cpu(), tuple(gradient.cpu() for gradient in gradients)
+
+    expected_output, expected_gradients = run("cpu")
+    actual_output, actual_gradients = run("mps")
+
+    torch.testing.assert_close(actual_output, expected_output, rtol=1e-5, atol=1e-6)
+    for actual, expected in zip(actual_gradients, expected_gradients):
+        torch.testing.assert_close(actual, expected, rtol=1e-4, atol=1e-5)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- build Objective-C++ Metal sources on macOS using the pixi-configured Homebrew LLVM/OpenMP toolchain
- implement `philtorch::lti_recur` on MPS with a replay-only hierarchical affine scan
- cover scalar, shared, and batched coefficients across SIMD, tile, and chunk boundaries and verify autograd parity
- add a reproducible PyTorch CPU/MPS runtime and peak-memory benchmark plus implementation documentation and a validated Mermaid execution graph
- configure Black in pixi and format all changed Python files

## Implementation

The Metal path reduces 512-element tiles using SIMD-group scans, exclusively scans compact tile totals, then replays each tile to emit outputs.
Replay avoids materializing a per-element local scan while retaining portable, fixed launch geometry across Apple GPUs.
MPS currently supports `float32`; unsupported dtypes fail explicitly.
CPU and CUDA behavior is unchanged.

## Benchmark

On an Apple M1 Pro with PyTorch 2.10.0 and six CPU threads, the documented cases measured MPS speedups from 1.77x to 9.88x.
Runtime uses `torch.utils.benchmark.Timer.blocked_autorange` and reports median latency with IQR.
CPU peak memory is reconstructed from `torch.profiler` allocation events, while MPS peak memory uses PyTorch MPS allocator sampling inside a profiler range because MPS is not available as a profiler activity.
For multi-batch cases, measured peak native tensor memory is approximately 1.98x smaller on MPS.
Input transfers and allocator cache are excluded.

## Review

A code review verified kernel indexing, hierarchy composition, overflow checks, packaging, synchronized timing, and profiler accounting.
It also identified and fixed missing `zi` and `x` rank validation in the scalar fake implementation.
The MPS `float32` restriction remains an explicit documented limitation.

## Validation

- focused extension and PT2 tests: 75 passed, 21 skipped
- `pixi run black --check` on all changed Python files: passed
- PyTorch benchmark and profiler script: executed successfully
- source diagnostics and diff whitespace checks: clean